### PR TITLE
Add python-gpgme for checking signature of daemon installed during setup

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,7 @@ when "ubuntu","debian"
     key "5044912E"
   end
 
+  package "python-gpgme"
   package "dropbox"
 when "arch"
   include_recipe "pacman"


### PR DESCRIPTION
Ah, found something else that the installer recommends. It doesn't require it, but it's needlessly forgoing easy additional security without it :)
